### PR TITLE
Fixing the reference page of the pkgdown website with categories.

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,1 +1,38 @@
 destination: docs
+reference:
+- title: "Copula constructors"
+  desc: >
+    Functions that construct a copula object (and corresponding S4 classes),
+    that can be (generally) builded from data and parameters.
+- contents:
+  - Cort
+  - CortForest
+  - ConvexCombCopula
+  - cbCopula
+  - cbkmCopula
+- title: "(r/d/p/v)Copula functions"
+  desc: "Random number generation, density, cdf, and volume functions for the copulas."
+- contents:
+  - rCopula
+  - dCopula
+  - pCopula
+  - vCopula
+- title: "Usefull methods"
+  desc: "Some S4 methods that are included as convenience functions"
+- contents:
+  - biv_rho
+  - biv_tau
+  - kendall_func
+  - loss
+  - project_on_dims
+  - quad_norm
+  - quad_prod
+  - quad_prod_with_data
+  - constraint_infl
+- title: "Datasets"
+  desc: "Four simulated datasets are included for testing and demonstration purposes"
+- contents:
+  - funcdep_data
+  - clayton_data
+  - impossible_data
+  - recoveryourself_data


### PR DESCRIPTION
Fixing the reference index, you can now see that the CamelCase and snake_case switches are to seperate constructors and standard (r/d/p/v)-functions from methods and the rest. Take a look at the new reference, you will see that the common uses of the two standards makes sense now that it's ordered.

For the last minor note : N is the number of bootstraps, and is intensionally given in uppercase as it is common in R, see e.g boot::boot, and many others.