### PR TITLE
closes #29. Adding documentation for slots of S4 objects. 

### DIFF
--- a/R/Cort.R
+++ b/R/Cort.R
@@ -49,8 +49,8 @@ NULL
 #' @param number_max_dim The maximum number of dimension a split occurs in. Defaults to be all of the dimensions.
 #' @param slsqp_options options for nloptr::slsqp to find breakpoints : you can change defaults.
 #' @param verbose_lvl numeric. set the verbosity. 0 for no output and bigger you set it the most output you get.
-#' @param N The number of bootstrap resamples for p_values computations.
-#' @param osqp_options options for the weights optimisation. You can pass a call to osqp::osqpSettings, or NULL for defaults.
+#' @param N The number of bootstrap samples for p_values computations.
+#' @param osqp_options options for the weights optimization. You can pass a call to osqp::osqpSettings, or NULL for defaults.
 #' @param force_grid Set to TRUE to force breakpoints to be on the n-checkerboard grid.
 #'
 #' @name Cort-Class
@@ -58,6 +58,20 @@ NULL
 #' @rdname Cort-Class
 #'
 #' @return An instance of the `Cort` S4 class. The object represent the fitted copula and can be used through several methods to query classical (r/d/p/v)Copula methods, constraint influence, etc.
+#' Beside returning some inputted parameters, notable slots are :
+#'
+#' \itemize{
+#'  \item{`data` }{Your original data}
+#'  \item{`dim` }{The dimension of problem, number of columns of your dataset}
+#'  \item{`f` }{The empirical frequency in the leaves}
+#'  \item{`p` }{The fitted probabilities of each leaf}
+#'  \item{`a` }{Minimum points of leaves}
+#'  \item{`b` }{Maximum points of leaves}
+#'  \item{`vols` }{Volume of the leaves}
+#' }
+#'
+#' More details about these slots can be found in the reference.
+#'
 #' @export
 #'
 #' @references

--- a/R/CortForest.R
+++ b/R/CortForest.R
@@ -49,6 +49,21 @@
 #' @rdname CortForest-Class
 #'
 #' @return An instance of the `CortForest` S4 class. The object represent the fitted copula and can be used through several methods to query classical (r/d/p/v)Copula methods, constraint influence, etc.
+#' Beside returning some inputted parameters, notable slots are :
+#'
+#' \itemize{
+#'  \item{`trees` }{A list of Cort objects representing each fitted tree in the forest.}
+#'  \item{`weights` }{The weigths of each tree.}
+#'  \item{`indexes` }{The indexes of data points that were selected for fitting the trees}
+#'  \item{`pmf` }{The density of each tree on data points}
+#'  \item{`norm_matrix` }{The matrix of scalar product between trees}
+#'  \item{`oob_pmf` }{The density of each tree on data points it did not see during fitting}
+#'  \item{`oob_kl` }{The out-of-bag Kullback-Leibler divergence of each tree }
+#'  \item{`oob_ise` }{The out-of-bag Integrated Square Error of each tree}
+#' }
+#'
+#' More details about these slots can be found in the reference.
+#'
 #' @export
 #'
 #' @references

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,7 @@
 AppVeyor
 Assymptotics
 CLI
+CamelCase
 Cherubini
 Codecov
 ConvexCombCopula
@@ -16,6 +17,8 @@ Finalised
 Genest
 Github
 ISSN
+Kullback
+Leibler
 LifeCycleSavings
 Masiello
 Maume
@@ -78,7 +81,6 @@ nloptr
 notin
 oct
 oob
-optimisation
 osqp
 osqpSettings
 pCopula
@@ -98,3 +100,4 @@ thoose
 travis
 usecases
 visualise
+weigths

--- a/man/Cort-Class.Rd
+++ b/man/Cort-Class.Rd
@@ -33,14 +33,27 @@ Cort(
 
 \item{slsqp_options}{options for nloptr::slsqp to find breakpoints : you can change defaults.}
 
-\item{osqp_options}{options for the weights optimisation. You can pass a call to osqp::osqpSettings, or NULL for defaults.}
+\item{osqp_options}{options for the weights optimization. You can pass a call to osqp::osqpSettings, or NULL for defaults.}
 
-\item{N}{The number of bootstrap resamples for p_values computations.}
+\item{N}{The number of bootstrap samples for p_values computations.}
 
 \item{force_grid}{Set to TRUE to force breakpoints to be on the n-checkerboard grid.}
 }
 \value{
 An instance of the \code{Cort} S4 class. The object represent the fitted copula and can be used through several methods to query classical (r/d/p/v)Copula methods, constraint influence, etc.
+Beside returning some inputted parameters, notable slots are :
+
+\itemize{
+\item{\code{data} }{Your original data}
+\item{\code{dim} }{The dimension of problem, number of columns of your dataset}
+\item{\code{f} }{The empirical frequency in the leaves}
+\item{\code{p} }{The fitted probabilities of each leaf}
+\item{\code{a} }{Minimum points of leaves}
+\item{\code{b} }{Maximum points of leaves}
+\item{\code{vols} }{Volume of the leaves}
+}
+
+More details about these slots can be found in the reference.
 }
 \description{
 Cort class

--- a/man/CortForest-Class.Rd
+++ b/man/CortForest-Class.Rd
@@ -41,6 +41,20 @@ CortForest(
 }
 \value{
 An instance of the \code{CortForest} S4 class. The object represent the fitted copula and can be used through several methods to query classical (r/d/p/v)Copula methods, constraint influence, etc.
+Beside returning some inputted parameters, notable slots are :
+
+\itemize{
+\item{\code{trees} }{A list of Cort objects representing each fitted tree in the forest.}
+\item{\code{weights} }{The weigths of each tree.}
+\item{\code{indexes} }{The indexes of data points that were selected for fitting the trees}
+\item{\code{pmf} }{The density of each tree on data points}
+\item{\code{norm_matrix} }{The matrix of scalar product between trees}
+\item{\code{oob_pmf} }{The density of each tree on data points it did not see during fitting}
+\item{\code{oob_kl} }{The out-of-bag Kullback-Leibler divergence of each tree }
+\item{\code{oob_ise} }{The out-of-bag Integrated Square Error of each tree}
+}
+
+More details about these slots can be found in the reference.
 }
 \description{
 CortForest class

--- a/man/loss-methods.Rd
+++ b/man/loss-methods.Rd
@@ -25,7 +25,7 @@ Compute the loss of the model.
 }}
 
 \examples{
-cop <- Cort(cort::recoveryourself_data)
+cop <- Cort(cort::recoveryourself_data[1:10,])
 loss(cop)
 
 }


### PR DESCRIPTION
Only Cort and CortForest needed some, the other objects were alrady fully covered (parameters of the constructor == slots).